### PR TITLE
Add missing `githubEditUrl` prop

### DIFF
--- a/docs/src/layouts/DocsLayout.astro
+++ b/docs/src/layouts/DocsLayout.astro
@@ -41,7 +41,7 @@ const githubEditUrl = githubRepoDocsUrl + relativeFile
           <MoreMenu githubEditUrl={githubEditUrl} />
           <Footer />
         </main>
-        <TableOfContents headings={Astro.props.headings} />
+        <TableOfContents headings={Astro.props.headings} githubEditUrl={githubEditUrl} />
       </div>
     </div>
     <IframeNoFlash />


### PR DESCRIPTION
## 🐛  the bug
Noticed that `Edit this page on GitHub` was not working on the docs site on desktop:
    <img width="247" alt="image" src="https://user-images.githubusercontent.com/25834218/188247776-d4ca27d2-f978-4908-9a5c-0ffd5cda0e5f.png">

The equivalent link on mobile works fine ✔️ 

## 🤔 underlying issue

`TableOfContents` in `docs/src/layouts/DocsLayout.astro` is missing the `githubEditUrl` prop, which makes the href undefined when viewing the docs on desktop.

## ✨ this pr
This PR adds in the missing prop. Tested locally and `Edit this page on GitHub` now contains the correct link.