### PR TITLE
Pass empty object to api plugin

### DIFF
--- a/packages/core/src/plugins/api.js
+++ b/packages/core/src/plugins/api.js
@@ -5,7 +5,7 @@ import { templateDefaultId } from './template.js'
  * @param {import('..').Options} [options]
  * @returns {import('vite').Plugin}
  */
-export function apiPlugin(options) {
+export function apiPlugin(options = {}) {
   /** @type {Map<string, string>} */
   const virtualIdToCode = new Map()
 


### PR DESCRIPTION
Currently running the example code as seen [here](https://whyframe.dev/docs/integrations/sveltekit/) fails with the error:

`TypeError: Error while preprocessing [...]/.svelte-kit/generated/root.svelte - Cannot read properties of undefined (reading 'components')`.

This is because while all properties of the options object are nicely optionally chained, not passing in an object into the core `whyframe()` plugin (as suggested in the [docs](https://whyframe.dev/docs/integrations/sveltekit/) under setup) causes the options object itself to be `undefined`. 

There are multiple ways to solve this, at least those:
- make passing in an object mandatory
- optional chain all references to `options`
- pass in an empty object by default

I chose the latter one since it results in the smallest code change.

Feel free to close this and go with something else.